### PR TITLE
 jenkins/papr: more PAPR integration improvements 

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -38,9 +38,17 @@ Assuming you already have a cluster set up and running (e.g. `oc cluster up`):
 
 ```
 $ oc new-project projectatomic-ci
-$ echo "$GITHUB_TOKEN" > mytoken
+$ echo -n "$GITHUB_TOKEN" > mytoken
 $ oc secrets new github-token token=mytoken
 $ oc new-app --file paci-jenkins.yaml
+```
+
+If you're also planning to test publishing results to AWS S3:
+
+```
+$ echo -n "$AWS_ACCESS_KEY_ID" > aws-key-id
+$ echo -n "$AWS_SECRET_ACCESS_KEY" > aws-key-secret
+$ oc secrets new aws-access-key id=aws-key-id secret=aws-key-secret
 ```
 
 If your project already exists (e.g. you are not a cluster admin) and it is not
@@ -150,6 +158,12 @@ Note that hacking on the PAPR codebase *itself* doesn't require Jenkins, only a
 working OpenShift cluster. See the PAPR
 [instructions](https://github.com/projectatomic/papr/blob/ocp/docs/RUNNING.md)
 for more details on how to get started.
+
+The `papr` service account needs to have a membership in an SCC with `RunAsAny`,
+so that it can run test containers as root, much like Docker. In the
+`oc cluster up` case, this can be done simply by adding the papr service account
+to the `anyuid` SCC. Otherwise, you'll need to ask a cluster administrator to do
+this for you.
 
 To be able to trigger PAPR tests from GHPRB jobs in Jenkins, you simply need to
 build the PAPR image:

--- a/jenkins/paci-jenkins.yaml
+++ b/jenkins/paci-jenkins.yaml
@@ -144,6 +144,20 @@ objects:
   - kind: ServiceAccount
     name: papr
 - apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: papr-config
+  data:
+    config: |
+      github:
+        auth-from-env: true
+      publisher:
+        type: s3
+        config:
+          auth-from-env: true
+          bucket: aos-ci
+          rootdir: ghprb
+- apiVersion: v1
   kind: Route
   metadata:
     annotations:
@@ -245,7 +259,9 @@ objects:
             claimName: ${JENKINS_SERVICE_NAME}
         - name: github-token-mount
           secret:
-            secretName: ${GITHUB_TOKEN_SECRET}
+            # we expect users to have created a secret called github-token with
+            # the key "token" containing the actual token
+            secretName: github-token
         - name: webhook-secret-mount
           secret:
             secretName: webhook-secret
@@ -376,13 +392,6 @@ parameters:
 - description: Git branch/tag reference
   name: PAPR_REPO_REF
   value: master
-- description: >
-    GitHub token secret. This is *not* the token itself. It is the name of the
-    OpenShift secret containing the token, which must be created beforehand. The
-    secret is expected to define a key "token" containing the token.
-  name: GITHUB_TOKEN_SECRET
-  value: github-token
-  required: true
 - description: Shared webhook secret.
   name: GITHUB_WEBHOOK_SHARED_SECRET
   generate: expression

--- a/jenkins/paci-jenkins.yaml
+++ b/jenkins/paci-jenkins.yaml
@@ -22,6 +22,22 @@ objects:
   metadata:
     name: paci-jenkins
     namespace: ${NAMESPACE}
+# this is a version of the openshift/jenkins locked to stable openshift tags,
+# since we're using v3.6, which didn't do this versioning
+# see: https://github.com/openshift/jenkins/issues/528#issuecomment-378381468
+# Once we move away from v3.6, we can drop this and change the paci-jenkins bc
+# to use the openshift/jenkins:2 tag
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: jenkins
+    namespace: ${NAMESPACE}
+  spec:
+    tags:
+      - name: stable
+        from:
+          kind: DockerImage
+          name: openshift/jenkins-2-centos7:v3.9
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -41,8 +57,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: jenkins:latest
-          namespace: openshift
+          name: jenkins:stable
         forcePull: true
     output:
       to:

--- a/papr/papr-trigger.py
+++ b/papr/papr-trigger.py
@@ -72,7 +72,8 @@ def generate_papr_pod(args):
                     "name": "papr",
                     "image": "172.30.1.1:5000/projectatomic-ci/papr",
                     "imagePullPolicy": "Always",
-                    "args": ["--debug", "--repo", args.repo],
+                    "args": ["--debug", "runtest", "--conf",
+                             "/etc/papr.conf", "--repo", args.repo],
                     # XXX: pvc for git checkout caches
                     # XXX: mount site.yaml configmap
                     "volumeMounts": [


### PR DESCRIPTION
- use ConfigMap to mount PAPR config
- add AWS secrets
- inject secrets using env vars
- let OCP auto-generate PAPR pod names rather than us doing it, which is
  inherently racy

---

With these patches, I can successfully run the full pipeline end to end. There are three major items left before we can start running using this for real:

1. GC for PAPR pods
2. set up owner references for child pods: https://github.com/projectatomic/papr/blob/6e421b09ec802b5239c76d7b0dc8fbc9bfec6d4f/papr/testenvs/container.py#L72
3. shared PV for cache

None of these are especially difficult, though I'm thinking of making these things subtasks so that others can learn how to contribute. In the meantime, I'd like to get an OpenShift instance going in AWS for early testing. Will also poke CentOS folks to get the necessary mods done.