### PR TITLE
papr: add ostreedev/ostree repo

### DIFF
--- a/jenkins/jjb/papr.yaml
+++ b/jenkins/jjb/papr.yaml
@@ -130,6 +130,9 @@
       - papr-jobs:
           ghowner: jlebon
           ghrepo: papr-sandbox
+      - papr-jobs:
+          ghowner: ostreedev
+          ghrepo: ostree
 
 - job:
     name: 'papr-pod-gc'


### PR DESCRIPTION
I also deleted the whitelist empty file for `jlebon/papr-sandbox`. Let's not do whitelists anymore. As long as users are in one of the accepted orgs, they're automatically whitelisted.